### PR TITLE
Fixes #1 Closes #2

### DIFF
--- a/json2nbt.go
+++ b/json2nbt.go
@@ -268,6 +268,25 @@ func writePayload(w io.Writer, byteOrder binary.ByteOrder, m map[string]interfac
 		} else {
 			return JsonParseError{"Tag Int Array value field not an array", err}
 		}
+	case 12:
+		if values, ok := m["value"].([]interface{}); ok {
+			err = binary.Write(w, byteOrder, int64(len(values)))
+			if err != nil {
+				return JsonParseError{"Error writing int64 array length", err}
+			}
+			for _, value := range values {
+				if i, ok := value.(float64); ok {
+					err = binary.Write(w, byteOrder, int64(i))
+					if err != nil {
+						return JsonParseError{"Error writing element of int64 array", err}
+					}
+				} else {
+					return JsonParseError{"Tag Int value field not a number", err}
+				}
+			}
+		} else {
+			return JsonParseError{"Tag Int Array value field not an array", err}
+		}
 	default:
 		return JsonParseError{"tagType " + strconv.Itoa(int(tagType)) + " is not recognized", err}
 	}

--- a/json2nbt.go
+++ b/json2nbt.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"strconv"
 
 	"github.com/ghodss/yaml"
@@ -161,7 +162,13 @@ func writePayload(w io.Writer, byteOrder binary.ByteOrder, m map[string]interfac
 				return JsonParseError{"Error writing float64 payload", err}
 			}
 		} else {
-			return JsonParseError{"Tag Byte value field not a number", err}
+			// return JsonParseError{"Tag Byte value field not a number", err}
+			f = math.NaN()
+			err = binary.Write(w, byteOrder, f)
+			if err != nil {
+				return JsonParseError{"Error writing float64 payload", err}
+			}
+
 		}
 	case 7:
 		if values, ok := m["value"].([]interface{}); ok {

--- a/nbt2json.go
+++ b/nbt2json.go
@@ -121,7 +121,7 @@ func getTag(r *bytes.Reader, byteOrder binary.ByteOrder) ([]byte, error) {
 		return nil, err
 	}
 	outJson, err := json.MarshalIndent(data, "", "  ")
-	return outJson, nil
+	return outJson, err
 }
 
 // Gets the tag payload. Had to break this out from the main function to allow tag list recursion

--- a/nbt2json.go
+++ b/nbt2json.go
@@ -253,6 +253,21 @@ func getPayload(r *bytes.Reader, byteOrder binary.ByteOrder, tagType byte) (inte
 			intArray = append(intArray, oneInt)
 		}
 		output = intArray
+	case 12:
+		var longArray []int64
+		var numRecords, oneInt int64
+		err := binary.Read(r, byteOrder, &numRecords)
+		if err != nil {
+			return nil, NbtParseError{"Reading long array tag length", err}
+		}
+		for i := int64(1); i <= numRecords; i++ {
+			err := binary.Read(r, byteOrder, &oneInt)
+			if err != nil {
+				return nil, NbtParseError{"Reading long in long array tag", err}
+			}
+			longArray = append(longArray, oneInt)
+		}
+		output = longArray
 	default:
 		return nil, NbtParseError{"TagType not recognized", nil}
 	}

--- a/nbt2json.go
+++ b/nbt2json.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/ghodss/yaml"
@@ -172,7 +173,11 @@ func getPayload(r *bytes.Reader, byteOrder binary.ByteOrder, tagType byte) (inte
 		if err != nil {
 			return nil, NbtParseError{"Reading float64", err}
 		}
-		output = f
+		if math.IsNaN(f) {
+			output = "NaN"
+		} else {
+			output = f
+		}
 	case 7:
 		var byteArray []int8
 		var oneByte int8

--- a/nbt2json/main.go
+++ b/nbt2json/main.go
@@ -20,7 +20,7 @@ func main() {
 	var skipBytes int
 	app := cli.NewApp()
 	app.Name = "NBT to JSON"
-	app.Version = "0.2.0"
+	app.Version = "0.2.1"
 	app.Compiled = time.Now()
 	app.Authors = []cli.Author{
 		cli.Author{
@@ -28,7 +28,7 @@ func main() {
 			Email: "jim@jimnelson.us",
 		},
 	}
-	app.Copyright = "(c) 2018 Jim Nelson"
+	app.Copyright = "(c) 2018, 2019 Jim Nelson"
 	app.Usage = "Converts NBT-encoded data to JSON | https://github.com/midnightfreddie/nbt2json"
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{

--- a/nbt2json/main.go
+++ b/nbt2json/main.go
@@ -20,7 +20,7 @@ func main() {
 	var skipBytes int
 	app := cli.NewApp()
 	app.Name = "NBT to JSON"
-	app.Version = "0.2.1"
+	app.Version = "0.3.0"
 	app.Compiled = time.Now()
 	app.Authors = []cli.Author{
 		cli.Author{


### PR DESCRIPTION
Fixes:

- Now returns error if JSON marshaling fails
- Handles double/float64 NaN
- Handles new tag type 12 for array of long/int64 (untested)

Increment version to 0.3.0, added 2019 copyright year.