### PR TITLE
Fix losing precision on 64-bit UUIDs due to float64 interpretation

### DIFF
--- a/nbt2json.go
+++ b/nbt2json.go
@@ -15,7 +15,7 @@ import (
 const Name = "Named Binary Tag to JSON"
 
 // Version is the json document's nbt2JsonVersion:
-const Version = "0.3.0"
+const Version = "0.3.1"
 
 // nbt2JsonUrl is inserted in the first tag as nbt2JsonUrl
 const nbt2JsonUrl = "https://github.com/midnightfreddie/nbt2json"

--- a/nbt2json/main.go
+++ b/nbt2json/main.go
@@ -20,7 +20,7 @@ func main() {
 	var skipBytes int
 	app := cli.NewApp()
 	app.Name = "NBT to JSON"
-	app.Version = "0.3.0"
+	app.Version = "0.3.1"
 	app.Compiled = time.Now()
 	app.Authors = []cli.Author{
 		cli.Author{


### PR DESCRIPTION
I patched the code to work before I saw https://github.com/brickyluke/nbt2json/commit/793068228b0e4ab6849629b04d068a33a5ce84f5 fork and changes, basically the same bugfix. But he doesn't seem interested in contributing back.

I adopted the bytes.NewBuffer idea from there (I monkey-patched it via strings→buffer initially, dealing for the first time with Go)

Without this all stored UUIDS would be _read back_ from JSON incorrectly, losing LSB precision resulting in incorrect numbers.

Not part of the PR is the fixing the library version changes. Good idea to do what he did and set permanent versions for libraries like he did (nbt2json needs very old versions compared to what's online). But you will know better than me what to do there ;)