### PR TITLE
More errors and tests

### DIFF
--- a/json2nbt.go
+++ b/json2nbt.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/json"
+	"fmt"
 	"io"
 	"math"
 	"strconv"
@@ -105,6 +106,9 @@ func writePayload(w io.Writer, byteOrder binary.ByteOrder, m map[string]interfac
 	switch tagType {
 	case 1:
 		if i, err := m["value"].(json.Number).Int64(); err == nil {
+			if i < math.MinInt8 || i > math.MaxInt8 {
+				return JsonParseError{fmt.Sprintf("%d is out of range for tag 1 - Byte", i), nil}
+			}
 			err = binary.Write(w, byteOrder, int8(i))
 			if err != nil {
 				return JsonParseError{"Error writing byte payload", err}
@@ -114,6 +118,9 @@ func writePayload(w io.Writer, byteOrder binary.ByteOrder, m map[string]interfac
 		}
 	case 2:
 		if i, err := m["value"].(json.Number).Int64(); err == nil {
+			if i < math.MinInt16 || i > math.MaxInt16 {
+				return JsonParseError{fmt.Sprintf("%d is out of range for tag 2 - Short", i), nil}
+			}
 			err = binary.Write(w, byteOrder, int16(i))
 			if err != nil {
 				return JsonParseError{"Error writing short payload", err}
@@ -123,6 +130,9 @@ func writePayload(w io.Writer, byteOrder binary.ByteOrder, m map[string]interfac
 		}
 	case 3:
 		if i, err := m["value"].(json.Number).Int64(); err == nil {
+			if i < math.MinInt32 || i > math.MaxInt32 {
+				return JsonParseError{fmt.Sprintf("%d is out of range for tag 3 - Int", i), nil}
+			}
 			err = binary.Write(w, byteOrder, int32(i))
 			if err != nil {
 				return JsonParseError{"Error writing int32 payload", err}
@@ -141,6 +151,9 @@ func writePayload(w io.Writer, byteOrder binary.ByteOrder, m map[string]interfac
 		}
 	case 5:
 		if f, err := m["value"].(json.Number).Float64(); err == nil {
+			if f != 0 && (math.Abs(f) < math.SmallestNonzeroFloat32 || math.Abs(f) > math.MaxFloat32) {
+				return JsonParseError{fmt.Sprintf("%g is out of range for tag 5 - Float", f), nil}
+			}
 			err = binary.Write(w, byteOrder, float32(f))
 			if err != nil {
 				return JsonParseError{"Error writing float32 payload", err}
@@ -171,6 +184,9 @@ func writePayload(w io.Writer, byteOrder binary.ByteOrder, m map[string]interfac
 			}
 			for _, value := range values {
 				if i, err := value.(json.Number).Int64(); err == nil {
+					if i < math.MinInt8 || i > math.MaxInt8 {
+						return JsonParseError{fmt.Sprintf("%d is out of range for Byte in tag 7 - Byte Array", i), nil}
+					}
 					err = binary.Write(w, byteOrder, int8(i))
 					if err != nil {
 						return JsonParseError{"Error writing element of byte array", err}
@@ -257,6 +273,9 @@ func writePayload(w io.Writer, byteOrder binary.ByteOrder, m map[string]interfac
 			}
 			for _, value := range values {
 				if i, err := value.(json.Number).Int64(); err == nil {
+					if i < math.MinInt32 || i > math.MaxInt32 {
+						return JsonParseError{fmt.Sprintf("%d is out of range for Int in tag 11 - Int Array", i), nil}
+					}
 					err = binary.Write(w, byteOrder, int32(i))
 					if err != nil {
 						return JsonParseError{"Error writing element of int32 array", err}

--- a/json2nbt.go
+++ b/json2nbt.go
@@ -45,9 +45,11 @@ func Json2Nbt(b []byte, byteOrder binary.ByteOrder) ([]byte, error) {
 	d2 := json.NewDecoder(bytes.NewBuffer(temp))
 	d2.UseNumber()
 	err = d2.Decode(&nbtArray)
-
 	if err != nil {
 		return nil, JsonParseError{"Error unmarshalling nbt: value", err}
+	}
+	if len(nbtArray) == 0 {
+		return nil, JsonParseError{"JSON input has no top-level value named nbt. Nbt data should be { \"nbt\": <HERE> }", err}
 	}
 	for _, nbtTag = range nbtArray {
 		err = writeTag(nbtOut, byteOrder, nbtTag)

--- a/nbt2json_test.go
+++ b/nbt2json_test.go
@@ -8,7 +8,7 @@ import (
 
 // NOTE: Only testing round-trips for consistency, but errors will still fail the test.
 
-// TODO: More thorough test json
+// TODO: Add list/array types to test json
 
 var testJson = `{
   "nbt": [
@@ -17,14 +17,72 @@ var testJson = `{
       "name": "",
       "value": [
         {
+          "tagType": 1,
+          "name": "TestByte",
+          "value": 64
+        },
+        {
           "tagType": 2,
-          "name": "Test",
-          "value": 256
+          "name": "TestShort",
+          "value": 32767
+        },
+        {
+          "tagType": 3,
+          "name": "TestInt",
+          "value": 2147483647
+        },
+        {
+          "tagType": 4,
+          "name": "TestLong",
+          "value": 9223372036854775807
+        },
+        {
+          "tagType": 5,
+          "name": "TestFloat",
+          "value": 1.234567e+38
+        },
+        {
+          "tagType": 6,
+          "name": "TestDouble",
+          "value": 1.23456789012345e+307
+        },
+        {
+          "tagType": 8,
+          "name": "TestString",
+          "value": "This is a test string"
+        },
+        {
+          "tagType": 0,
+          "name": "",
+          "value": null
         }
       ]
     }
   ]
 }`
+
+/*
+        {
+          "tagType": 7,
+          "name": "TestByteArray",
+          "value": 256
+        },
+				{
+					"tagType": 9,
+					"name": "TestList",
+					"value": 256
+				},
+				{
+					"tagType": 11,
+					"name": "TestIntArray",
+					"value": 256
+				},
+				{
+					"tagType": 12,
+					"name": "TestByteArray",
+					"value": 256
+				},
+*/
 
 func TestRoundTrip(t *testing.T) {
 	h := sha1.New()

--- a/nbt2json_test.go
+++ b/nbt2json_test.go
@@ -19,7 +19,7 @@ var testJson = `{
         {
           "tagType": 1,
           "name": "TestByte",
-          "value": 64
+          "value": 127
         },
         {
           "tagType": 2,


### PR DESCRIPTION
Fixes #12 
Fixes #13 

Json input without an "nbt" top-level value will throw error.
Valid ranges for numbers tags are now checked and will throw error when out of range
Additional Go tests added which would have caught these problems in the past code