### PR TITLE
WIP: Add ReadNbt2Json() to read NBT of length from bytes.Reader

### DIFF
--- a/nbt2json.go
+++ b/nbt2json.go
@@ -56,8 +56,8 @@ func intPairToLong(nbtLong NbtLong) int64 {
 }
 
 // Nbt2Yaml converts uncompressed NBT byte array to YAML byte array
-func Nbt2Yaml(b []byte, comment string) ([]byte, error) {
-	jsonOut, err := Nbt2Json(b, comment)
+func Nbt2Yaml(r *bytes.Reader, comment string, tagCount int) ([]byte, error) {
+	jsonOut, err := Nbt2Json(r, comment, tagCount)
 	if err != nil {
 		return nil, err
 	}
@@ -69,17 +69,16 @@ func Nbt2Yaml(b []byte, comment string) ([]byte, error) {
 }
 
 // Nbt2Json converts uncompressed NBT byte array to JSON byte array
-func Nbt2Json(b []byte, comment string) ([]byte, error) {
+func Nbt2Json(r *bytes.Reader, comment string, tagCount int) ([]byte, error) {
 	var nbtJson NbtJson
 	nbtJson.Name = Name
 	nbtJson.Version = Version
 	nbtJson.Nbt2JsonUrl = Nbt2JsonUrl
 	nbtJson.ConversionTime = time.Now().Format(time.RFC3339)
 	nbtJson.Comment = comment
-	buf := bytes.NewReader(b)
 	// var nbtJson.nbt []*json.RawMessage
-	for buf.Len() > 0 {
-		element, err := getTag(buf)
+	for i := 0; i < tagCount; i++ {
+		element, err := getTag(r)
 		if err != nil {
 			return nil, err
 		}

--- a/nbt2json_test.go
+++ b/nbt2json_test.go
@@ -144,7 +144,7 @@ func TestRoundTrip(t *testing.T) {
 	nbtHash := h.Sum(nbtData)
 
 	// Put that nbt through to json, get hash
-	jsonOut, err := Nbt2Json(bytes.NewReader(nbtData), "", 1)
+	jsonOut, err := Nbt2Json(nbtData, "")
 	if err != nil {
 		t.Fatal("Error in first Nbt2Json conversion:", err.Error())
 	}
@@ -163,7 +163,7 @@ func TestRoundTrip(t *testing.T) {
 	}
 
 	// Back to json again
-	jsonOut, err = Nbt2Json(bytes.NewReader(nbtData), "", 1)
+	jsonOut, err = Nbt2Json(nbtData, "")
 	if err != nil {
 		t.Fatal("Error in second Nbt2Json conversion:", err.Error())
 	}
@@ -187,7 +187,7 @@ func TestValueConversions(t *testing.T) {
 		} else if !bytes.Equal(nbtData, nbt) {
 			return fmt.Errorf(fmt.Sprintf("Tag type %d value %v, expected \n%s\n, got \n%s\n", tagType, value, hex.Dump(nbt), hex.Dump(nbtData)))
 		} else {
-			jsonData, err := Nbt2Json(bytes.NewReader(nbtData), "", 1)
+			jsonData, err := Nbt2Json(nbtData, "")
 			if err != nil {
 				return fmt.Errorf("Error in nbt re-conversion during value tests: %w", err)
 			} else {

--- a/nbt2json_test.go
+++ b/nbt2json_test.go
@@ -144,7 +144,7 @@ func TestRoundTrip(t *testing.T) {
 	nbtHash := h.Sum(nbtData)
 
 	// Put that nbt through to json, get hash
-	jsonOut, err := Nbt2Json(nbtData, "")
+	jsonOut, err := Nbt2Json(bytes.NewReader(nbtData), "", 1)
 	if err != nil {
 		t.Fatal("Error in first Nbt2Json conversion:", err.Error())
 	}
@@ -163,7 +163,7 @@ func TestRoundTrip(t *testing.T) {
 	}
 
 	// Back to json again
-	jsonOut, err = Nbt2Json(nbtData, "")
+	jsonOut, err = Nbt2Json(bytes.NewReader(nbtData), "", 1)
 	if err != nil {
 		t.Fatal("Error in second Nbt2Json conversion:", err.Error())
 	}
@@ -201,7 +201,7 @@ func TestValueConversions(t *testing.T) {
 		} else if !bytes.Equal(nbtData, tag.nbt) {
 			t.Error(fmt.Sprintf("Tag type %d value %d, expected \n%s\n, got \n%s\n", tag.tagType, tag.value, hex.Dump(tag.nbt), hex.Dump(nbtData)))
 		} else {
-			jsonData, err := Nbt2Json(nbtData, "")
+			jsonData, err := Nbt2Json(bytes.NewReader(nbtData), "", 1)
 			if err != nil {
 				t.Error("Error in nbt re-conversion during value tests:", err.Error())
 			} else {
@@ -235,7 +235,7 @@ func TestValueConversions(t *testing.T) {
 		} else if !bytes.Equal(nbtData, tag.nbt) {
 			t.Error(fmt.Sprintf("Tag type %d value %g, expected \n%s\n, got \n%s\n", tag.tagType, tag.value, hex.Dump(tag.nbt), hex.Dump(nbtData)))
 		} else {
-			jsonData, err := Nbt2Json(nbtData, "")
+			jsonData, err := Nbt2Json(bytes.NewReader(nbtData), "", 1)
 			if err != nil {
 				t.Error("Error in nbt re-conversion during value tests:", err.Error())
 			} else {
@@ -268,7 +268,7 @@ func TestValueConversions(t *testing.T) {
 		} else if !bytes.Equal(nbtData, tag.nbt) {
 			t.Error(fmt.Sprintf("Tag type %d value %v, expected \n%s\n, got \n%s\n", tag.tagType, value, hex.Dump(tag.nbt), hex.Dump(nbtData)))
 		} else {
-			jsonData, err := Nbt2Json(nbtData, "")
+			jsonData, err := Nbt2Json(bytes.NewReader(nbtData), "", 1)
 			if err != nil {
 				t.Error("Error in nbt re-conversion during value tests:", err.Error())
 			} else {
@@ -297,7 +297,7 @@ func TestValueConversions(t *testing.T) {
 		} else if !bytes.Equal(nbtData, tag.nbt) {
 			t.Error(fmt.Sprintf("Tag type %d value %v, expected \n%s\n, got \n%s\n", tag.tagType, tag.value, hex.Dump(tag.nbt), hex.Dump(nbtData)))
 		} else {
-			jsonData, err := Nbt2Json(nbtData, "")
+			jsonData, err := Nbt2Json(bytes.NewReader(nbtData), "", 1)
 			if err != nil {
 				t.Error("Error in nbt re-conversion during value tests:", err.Error())
 			} else {


### PR DESCRIPTION
I've been using a version of this code so I thought I'd submit the changes here in case they are of interest. In the long run I will probably end up converting NBT directly to a map or other Go structure which I think is out of scope for this project (although most of the required code is probably here)

ReadNbt2Json enables the caller to retrieve a specific number of NBT tags with an unknown byte length, from a byte slice. The caller may continue reading from the byte slice (passed as a bytes.Reader) after this function has been called. The new bedrock level format contains palettes in NBT format layered with blocks of palette indices describing sub chunks. I call this code [here](https://github.com/danhale-git/mine/blob/f164150865d4b74412a8eefd13381455c59015a8/terrain/subchunk.go#L172).

:)